### PR TITLE
feat: #43 핫이슈 기능 comment 순서 항상 created Desc로 조회하도록 개선

### DIFF
--- a/src/main/java/com/aztgg/api/hotissue/application/HotIssueService.java
+++ b/src/main/java/com/aztgg/api/hotissue/application/HotIssueService.java
@@ -44,7 +44,7 @@ public class HotIssueService {
         LocalDateTime now = LocalDateTime.now();
         List<GetHotIssueResponseDto> hotIssues = hotIssueRepository.findAllByStartAtLessThanEqualAndEndAtGreaterThanEqual(now, now)
                 .stream()
-                .map(a -> GetHotIssueResponseDto.fromLimitCommentDesc(a, 5))
+                .map(a -> GetHotIssueResponseDto.fromLimitCommentDesc(a, 3))
                 .toList();
         return new GetHotIssuesResponseDto(hotIssues);
     }

--- a/src/main/java/com/aztgg/api/hotissue/application/dto/GetHotIssueResponseDto.java
+++ b/src/main/java/com/aztgg/api/hotissue/application/dto/GetHotIssueResponseDto.java
@@ -55,8 +55,7 @@ public record GetHotIssueResponseDto(Long hotIssueId,
     }
 
     public static GetHotIssueResponseDto fromLimitCommentDesc(HotIssue hotIssue, int limitCount) {
-        // 코멘트는 역순으로 5개 조회
-        List<GetHotIssueResponseCommentDto> commentDtoList = hotIssue.getComments().reversed()
+        List<GetHotIssueResponseCommentDto> commentDtoList = hotIssue.getComments()
                 .stream()
                 .map(GetHotIssueResponseCommentDto::from)
                 .limit(limitCount)

--- a/src/main/java/com/aztgg/api/hotissue/domain/HotIssue.java
+++ b/src/main/java/com/aztgg/api/hotissue/domain/HotIssue.java
@@ -33,6 +33,7 @@ public class HotIssue {
     @Column(name = "content")
     private String content;
 
+    @OrderBy("createdAt DESC")
     @OneToMany(mappedBy = "hotIssue", cascade = {CascadeType.ALL})
     private List<HotIssueComment> comments = new ArrayList<>();
 


### PR DESCRIPTION
* 코멘트는 항상 createdAt의 DESC 순으로 조회해서 응답하도록 기능 변경
* activated-list 내 댓글 개수는 5 -> 3개로 수정