### PR TITLE
feat: #66 공고 리다이렉트 시 삭제된 공고라면 에러페이지로 이동

### DIFF
--- a/src/main/java/com/aztgg/api/recruitmentnotice/presentation/RecruitmentNoticeController.java
+++ b/src/main/java/com/aztgg/api/recruitmentnotice/presentation/RecruitmentNoticeController.java
@@ -1,12 +1,15 @@
 package com.aztgg.api.recruitmentnotice.presentation;
 
+import com.aztgg.api.global.exception.CommonException;
 import com.aztgg.api.recruitmentnotice.application.RecruitmentNoticeFacadeService;
 import com.aztgg.api.recruitmentnotice.application.RecruitmentNoticeService;
 import com.aztgg.api.recruitmentnotice.application.dto.*;
+import com.aztgg.api.recruitmentnotice.domain.RecruitmentNoticeErrorCode;
 import jakarta.servlet.http.HttpServletResponse;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.*;
 
@@ -21,11 +24,22 @@ public class RecruitmentNoticeController implements RecruitmentNoticeApi {
     private final RecruitmentNoticeService recruitmentNoticeService;
     private final RecruitmentNoticeFacadeService recruitmentNoticeFacadeService;
 
+    @Value("${page.error}")
+    private String errorPageUrl;
+
     @Override
     @GetMapping("/{recruitmentNoticeId}/redirect")
     public void redirectByRecruitmentNotice(HttpServletResponse response, @PathVariable Long recruitmentNoticeId) throws IOException {
-        GetRecruitmentNoticeRedirectionResponseDto responseDto = recruitmentNoticeService.incrementViewCountAndGetRecruitmentNoticeRedirection(recruitmentNoticeId);
-        response.sendRedirect(responseDto.url());
+        try {
+            GetRecruitmentNoticeRedirectionResponseDto responseDto = recruitmentNoticeService.incrementViewCountAndGetRecruitmentNoticeRedirection(recruitmentNoticeId);
+            response.sendRedirect(responseDto.url());
+        } catch (CommonException ce) {
+            if (ce.getErrorCode().equals(RecruitmentNoticeErrorCode.BAD_REQUEST_RECRUITMENT_NOTICE_NOT_FOUND)) {
+                response.sendRedirect(errorPageUrl + "?reason=%EC%9E%98%EB%AA%BB%EB%90%9C%20%ED%8E%98%EC%9D%B4%EC%A7%80%EB%A1%9C%20%EC%A0%91%EA%B7%BC%ED%96%88%EC%96%B4%EC%9A%94");
+                return;
+            }
+            throw ce;
+        }
     }
 
     @Override

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -31,6 +31,8 @@ management:
       exposure:
         include: "health"
 
+page:
+  error: https://nklcb.kr/error
 ---
 spring:
   config:


### PR DESCRIPTION
## 주요 변경 사항
### AS-IS
유저에게 이메일이 발송된 이후에 유저가 삭제된 공고를 클릭하면 404 에러 json 노출

### TO-BE
삭제된 공고 클릭 시 프론트 에러 페이지로 이동
https://www.nklcb.kr/error?reason=%EC%9E%98%EB%AA%BB%EB%90%9C%20%ED%8E%98%EC%9D%B4%EC%A7%80%EB%A1%9C%20%EC%A0%91%EA%B7%BC%ED%96%88%EC%96%B4%EC%9A%94

## 이슈 닫음
#66 
